### PR TITLE
HidingCheckBox: extend mapping for usual suspects...

### DIFF
--- a/tw2/dynforms/widgets.py
+++ b/tw2/dynforms/widgets.py
@@ -79,6 +79,20 @@ class HidingCheckBox(HidingComponentMixin, twf.CheckBox):
     __doc__ = HidingComponentMixin.__doc__.replace('$$', 'CheckBox')
     attrs = {'onclick': 'twd_hiding_onchange(this)'}
 
+    @classmethod
+    def post_define(cls):
+        if not hasattr(cls, 'mapping'):
+            return
+        # extend the mapping for the usual suspects of keys (truth values)
+        falsevals = (False, 0, 'false')
+        truevals = (True, 1, 'true')
+        for f in falsevals:
+            if f in cls.mapping:
+                [cls.mapping.setdefault(k, cls.mapping[f]) for k in falsevals]
+        for t in truevals:
+            if t in cls.mapping:
+                [cls.mapping.setdefault(k, cls.mapping(t)) for k in truevals]
+
 class HidingSelectionList(HidingComponentMixin, twf.widgets.SelectionList):
     def prepare(self):
         super(HidingSelectionList, self).prepare()


### PR DESCRIPTION
...of truth values. Necessary to hide stuff if the checkbox is
unchecked. Allows using True and False as keys in mappings.
